### PR TITLE
Update public import workflow and Google provider

### DIFF
--- a/.github/workflows/sync-to-source.yml
+++ b/.github/workflows/sync-to-source.yml
@@ -173,6 +173,7 @@ jobs:
             --branch-prefix "$COPYBARISTA_IMPORT_BRANCH_PREFIX" \
             --sync-label "$COPYBARISTA_SYNC_LABEL" \
             --report "$IMPORT_REPORT" \
+            --refresh-public-lockfile \
             --type-check-target . \
             --open-pr false
 

--- a/sagent/providers/google.py
+++ b/sagent/providers/google.py
@@ -46,6 +46,7 @@ from sagent.custom_types import (
 from sagent.lib.descriptors import is_image
 from sagent.lib.json import (
     MutableJSON,
+    MutableJSONValue,
     int_val,
     json_freeze,
     json_unfreeze,
@@ -104,6 +105,15 @@ class Google:
         ),
         "gemini-2.0-flash": ModelProfile(
             max_request_tokens=1_000_000,
+            max_response_tokens=65_536,
+            pricing=Pricing(
+                request=0.10,
+                response=0.40,
+                cache_read=0.025,
+            ),
+        ),
+        "gemini-2.5-flash-lite": ModelProfile(
+            max_request_tokens=1_048_576,
             max_response_tokens=65_536,
             pricing=Pricing(
                 request=0.10,
@@ -392,6 +402,7 @@ class _GeminiModel:
             msg = r.text.lower()
             if "too large" in msg or "too long" in msg or "context" in msg:
                 raise PromptTooLongError(r.text)
+            raise ValueError(f"Google API 400: {r.text}")
         r.raise_for_status()
         resp = _parse_response(r.json(), self._profile.pricing)
         logger.debug(
@@ -443,10 +454,31 @@ class _GeminiModel:
                 msg = err_body.lower()
                 if "too large" in msg or "too long" in msg or "context" in msg:
                     raise PromptTooLongError(err_body)
+                raise ValueError(f"Google API 400: {err_body}")
             r.raise_for_status()
             return await _consume_gemini_stream(
                 r, on_text=on_text, pricing=self._profile.pricing
             )
+
+
+def _strip_additional_properties(schema: MutableJSONValue) -> MutableJSONValue:
+    """Remove ``additionalProperties`` recursively for Gemini tool schemas."""
+    if isinstance(schema, dict):
+        schema_map = cast(MutableJSON, schema)
+        return cast(
+            MutableJSONValue,
+            {
+                k: _strip_additional_properties(v)
+                for k, v in schema_map.items()
+                if k != "additionalProperties"
+            },
+        )
+    if isinstance(schema, list):
+        return cast(
+            MutableJSONValue,
+            [_strip_additional_properties(item) for item in schema],
+        )
+    return schema
 
 
 def _build_request(
@@ -560,22 +592,30 @@ def _build_request(
         },
     )
     if request.system:
-        body["systemInstruction"] = {
-            "parts": [{"text": request.system}],
-        }
-    if request.tools:
-        body["tools"] = [
+        body["systemInstruction"] = cast(
+            MutableJSONValue,
             {
-                "functionDeclarations": [
-                    {
-                        "name": t.name,
-                        "description": t.description,
-                        "parameters": json_unfreeze(t.directive_schema),
-                    }
-                    for t in request.tools
-                ],
+                "parts": [{"text": request.system}],
             },
-        ]
+        )
+    if request.tools:
+        body["tools"] = cast(
+            MutableJSONValue,
+            [
+                {
+                    "functionDeclarations": [
+                        {
+                            "name": t.name,
+                            "description": t.description,
+                            "parameters": _strip_additional_properties(
+                                json_unfreeze(t.directive_schema)
+                            ),
+                        }
+                        for t in request.tools
+                    ],
+                },
+            ],
+        )
     return body
 
 

--- a/sagent/providers/google_test.py
+++ b/sagent/providers/google_test.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import json
+
 from PIL import Image
 
 import pytest
@@ -110,6 +112,13 @@ class TestProvider:
         m = p.model("gemini-2.0-flash")
         assert m.model_id == "gemini-2.0-flash"
         assert m.max_request_tokens == 1_000_000
+
+    def test_flash_lite_model_profile(self) -> None:
+        p: Provider = Google.from_key("AIza-test")
+        m = p.model("gemini-2.5-flash-lite")
+        assert m.model_id == "gemini-2.5-flash-lite"
+        assert m.max_request_tokens == 1_048_576
+        assert m.max_response_tokens == 65_536
 
     def test_model_custom_max_request_tokens(self) -> None:
         p: Provider = Google.from_key("AIza-test")
@@ -395,6 +404,49 @@ class TestSendMocked:
         ):
             resp = await model.buffer(request=ModelRequest(messages=[_user("hello")]))
         assert _text(resp) == "Hi!"
+        mock_resp.raise_for_status.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_buffer_non_prompt_size_400_raises_value_error(self) -> None:
+        provider = Google.from_key("AIza-test")
+        model = provider.model("gemini-2.0-flash")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "invalid generation config"
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch(
+                "sagent.providers.google.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(ValueError, match="Google API 400"),
+        ):
+            await model.buffer(request=ModelRequest(messages=[_user("hello")]))
+        mock_resp.raise_for_status.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_buffer_non_400_error_raises_http_status(self) -> None:
+        provider = Google.from_key("AIza-test")
+        model = provider.model("gemini-2.0-flash")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.raise_for_status = MagicMock(side_effect=RuntimeError("server"))
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch(
+                "sagent.providers.google.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(RuntimeError, match="server"),
+        ):
+            await model.buffer(request=ModelRequest(messages=[_user("hello")]))
+        mock_resp.raise_for_status.assert_called_once()
 
     @pytest.mark.anyio
     async def test_stream_basic(self) -> None:
@@ -444,6 +496,31 @@ class TestStreamOnText:
         assert _text(resp) == "Hello!"
         assert "Hello!" in chunks
 
+    @pytest.mark.anyio
+    async def test_stream_non_prompt_size_400_raises_value_error(self) -> None:
+        provider = Google.from_key("AIza-test")
+        model = provider.model("gemini-2.0-flash")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.aread = AsyncMock(return_value=b"invalid generation config")
+        mock_resp.raise_for_status = MagicMock()
+        stream_cm = AsyncMock()
+        stream_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+        stream_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_client = AsyncMock()
+        mock_client.stream = MagicMock(return_value=stream_cm)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch(
+                "sagent.providers.google.httpx.AsyncClient",
+                return_value=mock_client,
+            ),
+            pytest.raises(ValueError, match="Google API 400"),
+        ):
+            await model.stream(request=ModelRequest(messages=[_user("hi")]))
+        mock_resp.raise_for_status.assert_not_called()
+
 
 # -- _build_request with tools (line 242) ------------------------------
 
@@ -483,6 +560,53 @@ class TestBuildRequestWithTools:
         assert "tools" in body
         decls = body["tools"][0]["functionDeclarations"]
         assert decls[0]["name"] == "bash"
+
+    def test_additional_properties_stripped_recursively(self) -> None:
+        class _FakeTool:
+            def __init__(self) -> None:
+                self.name = "bash"
+                self.tool_id = "application/x-tool-bash"
+                self.description = "Run bash."
+                self.supports_microcompaction = False
+                self.directive_schema = json_freeze(
+                    {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "command": {
+                                "type": "string",
+                                "additionalProperties": False,
+                            },
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                },
+                            },
+                        },
+                    }
+                )
+
+            def summary(self, msg: Message) -> str:
+                del msg
+                return self.name
+
+            def summary_result(self, result: Message) -> str | None:
+                del result
+                return None
+
+            def prompt(self) -> str | None:
+                return None
+
+            async def run(self, msg: Message) -> Message:
+                del msg
+                return TextMessage("", "text/plain")
+
+        request = ModelRequest(messages=[_user("hello")], tools=[_FakeTool()])
+        body = cast(dict[str, Any], _build_request(request))
+        decls = body["tools"][0]["functionDeclarations"]
+        assert "additionalProperties" not in json.dumps(decls[0]["parameters"])
 
 
 class TestModelProperties:


### PR DESCRIPTION
<!-- This template keeps public contributions reviewable and prevents accidental leaks of credentials, generated files, or private environment state. -->

## Summary

Updates the public import workflow and Google provider behavior in Sagent.

## Highlights

- Updates `sync-to-source.yml` so generated public `uv.lock` files do not block source-owned public change imports.
- Refreshes Google provider request handling.
- Adds Google provider regression coverage.

## Testing

- [x] `uv run pytest`
- [x] `uv run ruff check --no-fix --no-cache .`
- [x] `uv run ruff format --check --no-cache .`
- [x] `uv run ty check`
- [x] `uv run basedpyright sagent`

----
Sagent export branch: `sagent/export/main`

Do not push manual commits to this generated branch. Change the source repository, then rerun the export workflow with the same branch.
