### PR TITLE
docs: add "Built with sagent" testimonial (agent-team / tuningfork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,38 @@ The [`examples/`](examples/) directory contains small, runnable examples:
 
 Start with the [tutorial](docs/tutorial.md), then use the examples as copyable patterns. See [Examples](examples/) and [Tools](docs/tools.md).
 
+## Built with sagent
+
+> *We used sagent to stand up a persistent, multi-agent dev team — then used
+> that team to ship and maintain a real library.*
+
+[**agent-team**](https://github.com/blackjax-devs/agent-team) is a development
+*channel* of five specialized agents — a tech lead, a senior and a junior
+engineer, a statistician, and a tech writer — running as one persistent server
+with a web UI. The agents message each other (`@swe`, `@statistician`) and hand
+off work the way a human team does. It's a thin role profile on top of sagent;
+sagent does the heavy lifting:
+
+- **Persistent sessions + resume** keep each agent's full history across
+  restarts, so the team picks a multi-day thread back up exactly where it left
+  off.
+- **Per-agent MCP servers** (`extra_mcp_servers`) inject a peer-messaging tool
+  into every agent — that's what turns five isolated CLIs into one channel.
+- **Unified cost tracking + `--max-budget-usd`** roll every agent's spend into
+  one number with a hard cap on the whole team.
+- **Sub-agent spawning** lets the tech lead fan work out to ephemeral helpers
+  and collect the results.
+
+We dogfood it daily on the [BlackJAX](https://github.com/blackjax-devs/blackjax)
+ecosystem. The team built and now maintains
+[**tuningfork**](https://github.com/blackjax-devs/tuningfork), a BlackJAX-native
+MCMC benchmark suite (14 models × 24 samplers × 10 warmups × 6 SMC methods): the
+statistician agent verifies algorithm-to-paper correctness and tunes sampler
+parameters, the engineers implement and run the benchmark loop, and the tech
+lead coordinates hand-offs and gates merges — all over sagent's channel.
+
+*Built something with sagent? Open a PR adding it here.*
+
 ## Security and privacy
 
 Sagent is an agent runtime, not a sandbox. Enabled tools run with the current


### PR DESCRIPTION
Adds a **Built with sagent** section to the README — a short real-world testimonial, placed right after `## Examples`.

**What it showcases:** [agent-team](https://github.com/blackjax-devs/agent-team), a persistent channel of five specialized agents (TL, two engineers, statistician, tech writer) running as one server with a web UI, built as a thin role profile on top of sagent. The agents peer-message each other and hand off work like a human team — and the section calls out exactly which sagent features make that possible:

- per-agent MCP servers (`extra_mcp_servers`) for peer messaging — the bit that turns N isolated CLIs into one channel
- persistent sessions + resume (multi-day threads survive restarts)
- unified cost tracking + `--max-budget-usd` across the whole team
- sub-agent spawning

It then notes the team dogfoods this daily and used it to build/maintain [tuningfork](https://github.com/blackjax-devs/tuningfork), a BlackJAX-native MCMC benchmark suite.

**Why:** the README documents sagent's capabilities well but has no "in the wild" example of them composing into a working product. This gives readers a concrete downstream build to point at (and a pattern to copy), with links back to both projects. Docs-only change; no code touched.

Happy to adjust wording, trim, or relocate the section if you'd prefer it elsewhere (e.g. a dedicated showcase/`USERS.md`).