### PR TITLE
Fix Claude/Codex subscription authentication and macOS onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable Sagent changes are documented here.
 
 ## Unreleased
 
+- Fixed CLI subscription authentication: `AnthropicCLI` now recognizes Claude
+  Code's native macOS login, `OpenAISubscription` honors `$CODEX_HOME`, and
+  zero-flag startup only tries allowed subscription providers.
 - Added GPT-5.6 Sol, Terra, and Luna to the OpenAI API-key and subscription
   providers, with GPT-5.6-specific `xhigh` and `max` effort handling. API-key
   users can select the 1.05M-window variants; subscription auth accepts the

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pipx install sagent
 
 ```bash
 brew install ripgrep fd pipx
-pipx install sagent
+pipx install --backend pip sagent
 ```
 
 ### Library
@@ -183,8 +183,12 @@ sagent/bin/cli.py --help
 Use Claude backend,
 
 ```
+claude auth login --claudeai
 sagent/bin/cli.py --allow-providers AnthropicCLI --provider AnthropicCLI --auth credentials
 ```
+
+`AnthropicCLI` inherits your HOME for macOS Keychain access and runs Claude
+non-interactively, so use it only in trusted working directories.
 
 ```bash
 export GOOGLE_API_KEY=...

--- a/sagent/agent/agent.py
+++ b/sagent/agent/agent.py
@@ -38,6 +38,7 @@ import asyncio
 import contextlib
 import contextvars
 import dataclasses
+import inspect
 import itertools
 import json
 import logging
@@ -1097,7 +1098,12 @@ class Agent:
         # failed/never-returning auth wedges the whole session. Off-load
         # to a worker thread so the loop keeps servicing input and the
         # wait stays cancellable.
-        await asyncio.to_thread(login_fn)
+        login_kwargs: dict[str, object] = {}
+        if spec.account is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                if "account" in inspect.signature(login_fn).parameters:
+                    login_kwargs["account"] = spec.account
+        await asyncio.to_thread(login_fn, **login_kwargs)
         # Reach the owning provider to hot-reload credentials after the
         # re-login. This is a deliberate private-attribute access, not a
         # capability probe: every rich provider model carries

--- a/sagent/agent/agent_test.py
+++ b/sagent/agent/agent_test.py
@@ -2267,6 +2267,50 @@ async def test_relogin_calls_login_classmethod() -> None:
 
 
 @pytest.mark.asyncio
+async def test_relogin_anthropic_cli_invokes_native_login() -> None:
+    """In-session ``/login`` reaches Claude Code instead of rejecting it."""
+    a = _build_agent_with_spec()
+    a.model_spec = types.model.ModelSpec(
+        provider="AnthropicCLI",
+        auth="credentials",
+        model_id="claude-opus-4-8",
+    )
+
+    with patch.object(providers_module.AnthropicCLI, "login") as login:
+        await a.relogin()
+
+    login.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_relogin_forwards_named_account() -> None:
+    """``/login`` refreshes the active credential slot, not the default one."""
+    a = _build_agent_with_spec()
+    a.model_spec = types.model.ModelSpec(
+        provider="OpenAISubscription",
+        auth="credentials",
+        model_id="gpt-5.6-sol",
+        account="work",
+    )
+    calls: list[str | None] = []
+
+    class _Provider:
+        @classmethod
+        def login(cls, *, account: str | None = None) -> None:
+            calls.append(account)
+
+    with patch.object(
+        providers_module,
+        "OpenAISubscription",
+        _Provider,
+        create=True,
+    ):
+        await a.relogin()
+
+    assert calls == ["work"]
+
+
+@pytest.mark.asyncio
 async def test_relogin_runs_blocking_login_off_event_loop() -> None:
     """``login`` blocks (browser/``input()`` wait); it must not freeze the loop.
 

--- a/sagent/bin/cli.py
+++ b/sagent/bin/cli.py
@@ -15,8 +15,14 @@ Usage::
     # Anthropic API key (reads ANTHROPIC_API_KEY)
     ./cli.py --provider Anthropic
 
+    # Claude subscription (reuses `claude auth login --claudeai`)
+    ./cli.py --provider AnthropicCLI
+
     # OpenAI
     ./cli.py --provider OpenAI --model gpt-5.6-sol
+
+    # ChatGPT subscription (reuses `codex login`)
+    ./cli.py --provider OpenAISubscription --model gpt-5.6-sol
 
     # Google
     ./cli.py --provider Google --auth env --model gemini-3.1-pro-preview
@@ -51,6 +57,7 @@ import dataclasses
 import json
 import logging
 import os
+import shlex
 import signal
 import sys
 import time
@@ -98,6 +105,11 @@ from sagent.tools.core import set_recipe
 
 _DEFAULT_PROVIDER = "Anthropic"
 _DEFAULT_AUTH = "env"
+_PROVIDER_STARTUP_ERRORS = (FileNotFoundError, RuntimeError, ValueError)
+_PROVIDER_ENV_HINTS = {
+    "Anthropic": "ANTHROPIC_API_KEY",
+    "Google": "GOOGLE_API_KEY",
+}
 
 
 def _default_allow_providers() -> tuple[str, ...]:
@@ -622,12 +634,19 @@ def _resolve_provider_and_allow(
 def _build_provider_model(
     args: argparse.Namespace,
     thinking_state: ThinkingState | None,
+    *,
+    allow_providers: tuple[str, ...] = PROVIDER_NAMES,
 ) -> tuple[types.providers.Provider, types.model.Model, str]:
     """Build the provider/model pair requested by CLI flags."""
     try:
         return _build_provider_model_once(args, thinking_state)
-    except (FileNotFoundError, ValueError) as error:
-        return _build_provider_model_fallback(args, thinking_state, error)
+    except _PROVIDER_STARTUP_ERRORS as error:
+        return _build_provider_model_fallback(
+            args,
+            thinking_state,
+            error,
+            allow_providers=allow_providers,
+        )
 
 
 def _build_provider_model_once(
@@ -670,30 +689,46 @@ def _build_provider_model_fallback(
     args: argparse.Namespace,
     thinking_state: ThinkingState | None,
     error: Exception,
+    *,
+    allow_providers: tuple[str, ...],
 ) -> tuple[types.providers.Provider, types.model.Model, str]:
     """Try another subscription provider for implicit startup auth failures."""
     if not _allow_implicit_provider_fallback(args):
         raise RuntimeError(
-            _credential_error_message(str(args.provider), error)
+            _credential_error_message(
+                str(args.provider),
+                error,
+                allow_providers=allow_providers,
+                account=args.account,
+            )
         ) from error
     original_provider = str(args.provider)
-    for fallback_provider in _credential_fallback_providers(original_provider):
+    for fallback_provider in _credential_fallback_providers(
+        original_provider,
+        allow_providers=allow_providers,
+    ):
         args.provider = fallback_provider
         args.auth = "credentials"
         args.model = None
         try:
             provider, model, auth = _build_provider_model_once(args, thinking_state)
-        except (FileNotFoundError, ValueError):
+        except _PROVIDER_STARTUP_ERRORS:
             continue
         sys.stderr.write(
             f"[provider] {original_provider} unavailable: {error}\n"
-            f"[provider] falling back to {fallback_provider} ({model.model_id}).\n"
-            f"[provider] To use {original_provider}, run: "
-            f"sagent --provider {original_provider} login\n"
+            f"[provider] using {fallback_provider} subscription login "
+            f"({model.model_id}).\n"
         )
         return provider, model, auth
     args.provider = original_provider
-    raise RuntimeError(_credential_error_message(original_provider, error)) from error
+    raise RuntimeError(
+        _credential_error_message(
+            original_provider,
+            error,
+            allow_providers=allow_providers,
+            account=args.account,
+        )
+    ) from error
 
 
 def _allow_implicit_provider_fallback(args: argparse.Namespace) -> bool:
@@ -702,6 +737,7 @@ def _allow_implicit_provider_fallback(args: argparse.Namespace) -> bool:
         bool(getattr(args, name, False))
         for name in (
             "provider_explicit",
+            "provider_from_resume",
             "auth_explicit",
             "account_explicit",
             "model_explicit",
@@ -709,23 +745,77 @@ def _allow_implicit_provider_fallback(args: argparse.Namespace) -> bool:
     )
 
 
-def _credential_fallback_providers(provider_name: str) -> tuple[str, ...]:
+def _credential_fallback_providers(
+    provider_name: str,
+    *,
+    allow_providers: tuple[str, ...] = PROVIDER_NAMES,
+) -> tuple[str, ...]:
     """Return implicit subscription providers to try after ``provider_name``."""
-    candidates = ("OpenAISubscription",)
-    return tuple(p for p in candidates if p != provider_name and p in PROVIDER_NAMES)
-
-
-def _credential_error_message(provider_name: str, error: Exception) -> str:
-    """Return an actionable credential-startup error."""
-    lines = [
-        f"{provider_name} credentials are unavailable: {error}",
-        "Try one of:",
-        f"  sagent --provider {provider_name} login",
-    ]
-    lines.extend(
-        f"  sagent --provider {fallback_provider}"
-        for fallback_provider in _credential_fallback_providers(provider_name)
+    candidates = ("AnthropicCLI", "OpenAISubscription")
+    return tuple(
+        candidate
+        for candidate in candidates
+        if candidate != provider_name and candidate in allow_providers
     )
+
+
+def _credential_setup_commands(
+    provider_name: str,
+    *,
+    account: str | None = None,
+) -> tuple[str, ...]:
+    """Return valid setup commands for one provider without inventing login APIs."""
+    account_name = account or "default"
+    account_args = (
+        "" if account_name == "default" else f" --account {shlex.quote(account_name)}"
+    )
+    if provider_name == "AnthropicCLI":
+        if account_args:
+            # Native Claude login writes only its default credential store;
+            # named AnthropicCLI accounts are legacy file slots and the
+            # provider error names their required path.
+            return ()
+        return ("claude auth login --claudeai", "sagent --provider AnthropicCLI")
+    if provider_name == "OpenAISubscription":
+        login = f"sagent --provider OpenAISubscription{account_args} login"
+        run = f"sagent --provider OpenAISubscription{account_args}"
+        if account_args:
+            return (login, run)
+        return ("codex login", login, run)
+    cls = getattr(providers, provider_name, None)
+    env_var = _PROVIDER_ENV_HINTS.get(
+        provider_name,
+        getattr(cls, "ENV_VAR", None),
+    )
+    if isinstance(env_var, str) and env_var:
+        return (f"export {env_var}=...",)
+    return ()
+
+
+def _credential_error_message(
+    provider_name: str,
+    error: Exception,
+    *,
+    allow_providers: tuple[str, ...] = PROVIDER_NAMES,
+    account: str | None = None,
+) -> str:
+    """Return an actionable credential-startup error."""
+    commands = list(_credential_setup_commands(provider_name, account=account))
+    for fallback_provider in _credential_fallback_providers(
+        provider_name,
+        allow_providers=allow_providers,
+    ):
+        commands.extend(
+            _credential_setup_commands(
+                fallback_provider,
+                account=account,
+            )
+        )
+    commands = list(dict.fromkeys(commands))
+    lines = [f"{provider_name} credentials are unavailable: {error}"]
+    if commands:
+        lines.append("Try one of:")
+        lines.extend(f"  {command}" for command in commands)
     return "\n".join(lines)
 
 
@@ -1290,6 +1380,7 @@ def main() -> int:
     # resumed session pinned one; otherwise it defaults to the first
     # allowed provider (``primary=None``).
     resumed_provider = loaded_session is not None and bool(loaded_session[0].provider)
+    args.provider_from_resume = resumed_provider
     explicit = bool(getattr(args, "provider_explicit", False)) or resumed_provider
     args.provider, allow_providers = _resolve_provider_and_allow(
         args.allow_providers,
@@ -1297,7 +1388,11 @@ def main() -> int:
     )
     try:
         thinking_state = _resolve_cli_thinking_state(args)
-        provider, model, resolved_auth = _build_provider_model(args, thinking_state)
+        provider, model, resolved_auth = _build_provider_model(
+            args,
+            thinking_state,
+            allow_providers=allow_providers,
+        )
         _validate_cli_thinking_state(model, thinking_state)
     except (AttributeError, FileNotFoundError, RuntimeError, ValueError) as e:
         sys.stderr.write(f"Error: {e}\n")
@@ -1418,6 +1513,18 @@ def _do_login(args: argparse.Namespace) -> None:
     login_fn = getattr(cls, "login", None)
     save_fn = getattr(cls, "save", None)
     if login_fn is None or save_fn is None:
+        if args.provider == "AnthropicCLI":
+            if args.account not in (None, "default"):
+                sys.stderr.write(
+                    "Error: AnthropicCLI named accounts use legacy credential "
+                    "files and do not support interactive login.\n"
+                )
+                sys.exit(1)
+            sys.stderr.write(
+                "Error: AnthropicCLI uses the Claude CLI login. Run:\n"
+                "  claude auth login --claudeai\n"
+            )
+            sys.exit(1)
         sys.stderr.write(
             f"Error: {args.provider} does not support interactive login.\n"
         )

--- a/sagent/bin/cli_test.py
+++ b/sagent/bin/cli_test.py
@@ -28,10 +28,14 @@ from sagent.bin.cli import (
     DEFAULT_TOOLS,
     _apply_resume_model_defaults,
     _build_persistent_child,
+    _build_provider_model,
     _build_provider_model_once,
     _cli_provider_options,
     _configure_logging,
+    _credential_error_message,
+    _credential_fallback_providers,
     _default_allow_providers,
+    _do_login,
     _event_to_json_record,
     _install_repl_logging,
     _last_assistant_text,
@@ -260,6 +264,236 @@ def test_implicit_provider_derives_auth_from_provider(
 
     assert calls == [("Anthropic", "env")]
     assert auth == "env"
+
+
+def test_implicit_startup_falls_back_from_missing_api_key_to_claude_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default missing-key RuntimeError reaches native subscription auth."""
+    ns = _parse([])
+    ns.provider = "Anthropic"
+    calls: list[tuple[str, str]] = []
+
+    class _Provider:
+        def model(self, model_id: str | None = None) -> object:
+            return argparse.Namespace(model_id=model_id or "claude-test")
+
+    def fake_build_provider(
+        provider_name: str,
+        auth: str,
+        **_kwargs: object,
+    ) -> object:
+        calls.append((provider_name, auth))
+        if provider_name == "Anthropic":
+            raise RuntimeError("Anthropic API key not configured.")
+        if provider_name == "AnthropicCLI":
+            return _Provider()
+        raise AssertionError(f"unexpected provider {provider_name}")
+
+    monkeypatch.setattr("sagent.bin.cli.build_provider", fake_build_provider)
+
+    _, model, auth = _build_provider_model(
+        ns,
+        None,
+        allow_providers=("Anthropic", "AnthropicCLI", "OpenAISubscription"),
+    )
+
+    assert calls == [
+        ("Anthropic", "env"),
+        ("AnthropicCLI", "credentials"),
+    ]
+    assert ns.provider == "AnthropicCLI"
+    assert model.model_id == "claude-test"
+    assert auth == "credentials"
+
+
+def test_resumed_provider_never_implicitly_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing credential must not rewrite a persisted session's provider."""
+    ns = _parse(["--resume", "abc123"])
+    meta = SessionMeta(
+        provider="Anthropic",
+        auth="env",
+        model_id="claude-sonnet-4-6",
+    )
+    _apply_resume_model_defaults(ns, meta)
+    ns.provider_from_resume = True
+    calls: list[tuple[str, str]] = []
+
+    def fake_build_provider(
+        provider_name: str,
+        auth: str,
+        **_kwargs: object,
+    ) -> object:
+        calls.append((provider_name, auth))
+        if provider_name != "Anthropic":
+            raise AssertionError(f"resume attempted fallback to {provider_name}")
+        raise RuntimeError("Anthropic API key not configured.")
+
+    monkeypatch.setattr("sagent.bin.cli.build_provider", fake_build_provider)
+
+    with pytest.raises(RuntimeError, match="Anthropic API key not configured"):
+        _build_provider_model(
+            ns,
+            None,
+            allow_providers=("Anthropic", "AnthropicCLI", "OpenAISubscription"),
+        )
+
+    assert calls == [("Anthropic", "env")]
+    assert ns.provider == "Anthropic"
+    assert ns.model == "claude-sonnet-4-6"
+
+
+def test_implicit_startup_fallback_honors_allow_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fallback never selects a provider excluded by the operator."""
+    ns = _parse([])
+    ns.provider = "Anthropic"
+    calls: list[tuple[str, str]] = []
+
+    class _Provider:
+        def model(self, model_id: str | None = None) -> object:
+            return argparse.Namespace(model_id=model_id or "gpt-test")
+
+    def fake_build_provider(
+        provider_name: str,
+        auth: str,
+        **_kwargs: object,
+    ) -> object:
+        calls.append((provider_name, auth))
+        if provider_name == "Anthropic":
+            raise RuntimeError("Anthropic API key not configured.")
+        if provider_name == "OpenAISubscription":
+            return _Provider()
+        raise AssertionError(f"excluded provider was attempted: {provider_name}")
+
+    monkeypatch.setattr("sagent.bin.cli.build_provider", fake_build_provider)
+
+    _, model, auth = _build_provider_model(
+        ns,
+        None,
+        allow_providers=("Anthropic", "OpenAISubscription"),
+    )
+
+    assert calls == [
+        ("Anthropic", "env"),
+        ("OpenAISubscription", "credentials"),
+    ]
+    assert ns.provider == "OpenAISubscription"
+    assert model.model_id == "gpt-test"
+    assert auth == "credentials"
+
+
+def test_credential_fallback_candidates_are_allowed_and_subscription_only() -> None:
+    assert _credential_fallback_providers(
+        "Anthropic",
+        allow_providers=("Anthropic", "OpenAISubscription"),
+    ) == ("OpenAISubscription",)
+    assert (
+        _credential_fallback_providers(
+            "AnthropicCLI",
+            allow_providers=("AnthropicCLI",),
+        )
+        == ()
+    )
+
+
+def test_anthropic_cli_error_names_real_login_command() -> None:
+    message = _credential_error_message(
+        "AnthropicCLI",
+        FileNotFoundError("logged out"),
+        allow_providers=("AnthropicCLI",),
+    )
+
+    assert "claude auth login" in message
+    assert "sagent --provider AnthropicCLI login" not in message
+
+
+def test_anthropic_api_error_names_required_environment_variable() -> None:
+    message = _credential_error_message(
+        "Anthropic",
+        RuntimeError("missing"),
+        allow_providers=("Anthropic",),
+    )
+
+    assert "Try one of:\n  export ANTHROPIC_API_KEY=..." in message
+
+
+def test_google_api_error_names_required_environment_variable() -> None:
+    message = _credential_error_message(
+        "Google",
+        RuntimeError("missing"),
+        allow_providers=("Google",),
+    )
+
+    assert "Try one of:\n  export GOOGLE_API_KEY=..." in message
+
+
+def test_openai_subscription_error_names_direct_sagent_login() -> None:
+    message = _credential_error_message(
+        "OpenAISubscription",
+        FileNotFoundError("missing"),
+        allow_providers=("OpenAISubscription",),
+    )
+
+    assert "codex login" in message
+    assert "sagent --provider OpenAISubscription login" in message
+
+
+def test_named_account_setup_commands_target_that_account() -> None:
+    openai_message = _credential_error_message(
+        "OpenAISubscription",
+        FileNotFoundError("missing"),
+        allow_providers=("OpenAISubscription",),
+        account="work",
+    )
+    assert "sagent --provider OpenAISubscription --account work login" in openai_message
+    assert "\n  codex login" not in openai_message
+
+    anthropic_message = _credential_error_message(
+        "AnthropicCLI",
+        FileNotFoundError("named legacy file required"),
+        allow_providers=("AnthropicCLI",),
+        account="work",
+    )
+    assert "Try one of:" not in anthropic_message
+    assert "claude auth login" not in anthropic_message
+
+
+def test_anthropic_cli_login_command_points_to_native_cli(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = argparse.Namespace(
+        provider="AnthropicCLI",
+        account=None,
+        headless=False,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _do_login(args)
+
+    assert exc.value.code == 1
+    assert "claude auth login" in capsys.readouterr().err
+
+
+def test_anthropic_cli_named_account_login_does_not_target_default(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = argparse.Namespace(
+        provider="AnthropicCLI",
+        account="work",
+        headless=False,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _do_login(args)
+
+    assert exc.value.code == 1
+    error = capsys.readouterr().err
+    assert "named accounts" in error
+    assert "claude auth login" not in error
 
 
 def test_parse_cli_args_session_paths() -> None:

--- a/sagent/providers/anthropic_cli.py
+++ b/sagent/providers/anthropic_cli.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 
 from sagent.lib import token_count
@@ -39,7 +40,7 @@ from sagent.providers.lib.errors import (
 )
 from sagent.providers.lib.hotspare import HotSpare
 from sagent.providers.lib.mcp_bridge import ToolsBridge
-from sagent.providers.lib.oauth import credentials_path
+from sagent.providers.lib.oauth import credentials_path, resolve_account
 from sagent.providers.lib.stop_reason import normalize_stop_reason
 from sagent.providers.lib.subproc import (
     _READ_IDLE_TIMEOUT_SEC,
@@ -82,6 +83,55 @@ logger = logging.getLogger(__name__)
 
 
 _CREDS_PATH = Path.home() / ".claude" / ".credentials.json"
+_AUTH_STATUS_TIMEOUT_SEC = 5.0
+_NON_SUBSCRIPTION_AUTH_ENV = frozenset(
+    {
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_AWS_API_KEY",
+        "ANTHROPIC_AWS_BASE_URL",
+        "ANTHROPIC_AWS_WORKSPACE_ID",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_BEDROCK_MANTLE_API_KEY",
+        "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "ANTHROPIC_FOUNDRY_API_KEY",
+        "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+        "ANTHROPIC_FOUNDRY_BASE_URL",
+        "ANTHROPIC_FOUNDRY_RESOURCE",
+        "ANTHROPIC_IDENTITY_TOKEN",
+        "ANTHROPIC_IDENTITY_TOKEN_FILE",
+        "ANTHROPIC_UNIX_SOCKET",
+        "ANTHROPIC_VERTEX_BASE_URL",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "CLAUDE_CODE_API_BASE_URL",
+        "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
+        "CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL",
+        "CLAUDE_CODE_CUSTOM_OAUTH_URL",
+        "CLAUDE_CODE_ENABLE_PROXY_AUTH_HELPER",
+        "CLAUDE_CODE_HFI_BEARER_TOKEN",
+        "CLAUDE_CODE_HOST_AUTH_ENV_VAR",
+        "CLAUDE_CODE_OAUTH_CLIENT_ID",
+        "CLAUDE_CODE_OAUTH_REFRESH_TOKEN",
+        "CLAUDE_CODE_OAUTH_SCOPES",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",
+        "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+        "CLAUDE_CODE_PROXY_AUTHENTICATE",
+        "CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH",
+        "CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH",
+        "CLAUDE_CODE_SESSION_ACCESS_TOKEN",
+        "CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "CLAUDE_CODE_USE_GATEWAY",
+        "CLAUDE_CODE_USE_MANTLE",
+        "CLAUDE_CODE_USE_VERTEX",
+    },
+)
 # Cap on waiting for the CLI to fetch the MCP catalog (proof the
 # in-process bridge connected) before feeding the first user line. The
 # CLI's MCP connect + catalog fetch is ~2-3s on a cold subprocess
@@ -104,6 +154,55 @@ _CREDENTIALS_SCHEMA: JSON = {
         },
     },
 }
+
+
+def _claude_auth_status(binary: str) -> bool | None:
+    """Return whether the native CLI has a Claude.ai subscription login.
+
+    Current Claude Code stores credentials in the macOS Keychain, so the
+    historical ``~/.claude/.credentials.json`` file is not an authoritative
+    login check there. ``None`` means the installed CLI predates
+    ``claude auth status --json`` or did not identify its auth method; callers
+    may then fall back to the legacy file check. Console/API/cloud auth returns
+    ``False`` because ``AnthropicCLI`` is the subscription provider.
+    """
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _NON_SUBSCRIPTION_AUTH_ENV
+    }
+    try:
+        proc = subprocess.run(  # noqa: S603 -- binary resolved by shutil.which
+            [binary, "auth", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=_AUTH_STATUS_TIMEOUT_SEC,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    try:
+        decoded: object = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    status = cast(MutableJSON, decoded)
+    logged_in = status.get("loggedIn")
+    if logged_in is False:
+        return False
+    if logged_in is not True:
+        return None
+    auth_method = status.get("authMethod")
+    if not isinstance(auth_method, str):
+        # Older CLIs that expose only ``loggedIn`` are not enough to prove
+        # subscription billing. Let the caller try the legacy OAuth file.
+        return None
+    api_provider = status.get("apiProvider")
+    return auth_method == "claude.ai" and (
+        api_provider is None or api_provider == "firstParty"
+    )
 
 
 class AnthropicCLIRetryableError(SubprocessTransportError):
@@ -243,9 +342,9 @@ class AnthropicCLI(Anthropic):
     """Provider that drives the user's installed ``claude`` CLI subprocess.
 
     Inherits ``KNOWN_MODELS`` (limits, pricing, tokenizer density) from
-    :class:`Anthropic`. Auth is the CLI's own credentials file --
-    ``~/.claude/.credentials.json`` for the default account or the
-    per-account variant produced by ``providers.lib.oauth.credentials_path``.
+    :class:`Anthropic`. The default account uses the CLI's native login
+    (including macOS Keychain storage); named accounts use the file variant
+    produced by ``providers.lib.oauth.credentials_path``.
     Cost figures are computed from the per-turn ``modelUsage`` summary
     the CLI emits on the terminal ``result`` event.
     """
@@ -261,7 +360,8 @@ class AnthropicCLI(Anthropic):
 
     def __init__(self, *, account: str | None = None) -> None:
         super().__init__(api_key="")
-        self._account = account
+        account_name = resolve_account(account)
+        self._account = None if account_name == "default" else account_name
 
     @classmethod
     @override
@@ -294,32 +394,101 @@ class AnthropicCLI(Anthropic):
 
     @classmethod
     def from_credentials(cls, *, account: str | None = None) -> AnthropicCLI:
-        """Build a provider that uses the local ``claude`` CLI's credentials.
+        """Build a provider that uses the local ``claude`` CLI login.
 
         Args:
           account: Named credential slot. ``None`` reads the legacy
-              unnamed credentials file.
+              native CLI login, including the macOS Keychain. Named accounts
+              use Sagent's legacy file-based credential slots.
 
         Returns:
           provider: Configured CLI-wrapping provider.
 
         Raises:
-          FileNotFoundError: If the resolved credentials file is absent.
+          FileNotFoundError: If the native CLI is logged out or a named
+              credentials file is absent.
           RuntimeError: If ``claude`` is not on ``PATH``.
 
         """
-        path = credentials_path(_CREDS_PATH, account)
-        if not path.exists():
-            raise FileNotFoundError(
-                f"AnthropicCLI: no credentials at {path}; run `claude login`.",
-            )
-        if _load_cli_credentials_file(path) is None:
-            raise ValueError(f"Invalid credentials file: {path}")
-        if shutil.which("claude") is None:
+        binary = shutil.which("claude")
+        if binary is None:
             raise RuntimeError(
                 "AnthropicCLI: `claude` is not on PATH; install the Claude CLI.",
             )
+        account_name = resolve_account(account)
+        is_default_account = account_name == "default"
+        if is_default_account:
+            logged_in = _claude_auth_status(binary)
+            if logged_in is True:
+                return cls(account=None)
+            if logged_in is False:
+                raise FileNotFoundError(
+                    "AnthropicCLI: Claude CLI has no active Claude.ai "
+                    "subscription login; run `claude auth login --claudeai`.",
+                )
+        path = credentials_path(_CREDS_PATH, account)
+        if not path.exists():
+            if not is_default_account:
+                raise FileNotFoundError(
+                    f"AnthropicCLI: no named-account credentials at {path}; "
+                    "named accounts require a legacy Claude credentials file "
+                    "at that path.",
+                )
+            raise FileNotFoundError(
+                f"AnthropicCLI: no credentials at {path}; run "
+                "`claude auth login --claudeai`.",
+            )
+        if _load_cli_credentials_file(path) is None:
+            raise ValueError(f"Invalid credentials file: {path}")
         return cls(account=account)
+
+    @classmethod
+    def login(cls, *, account: str | None = None) -> None:
+        """Run Claude Code's native Claude.ai login for the default account.
+
+        Named AnthropicCLI accounts are legacy file-backed slots and cannot be
+        targeted by Claude Code's interactive login command.
+
+        Args:
+          account: Account slot. ``None`` or ``"default"`` selects the native
+              Claude Code account.
+
+        Raises:
+          RuntimeError: If the Claude CLI is missing, its login command fails,
+              or the resulting Claude.ai login cannot be verified.
+          ValueError: If a named account is requested.
+
+        """
+        account_name = resolve_account(account)
+        if account_name != "default":
+            raise ValueError(
+                "AnthropicCLI named accounts use legacy credential files and "
+                "do not support interactive login.",
+            )
+        binary = shutil.which("claude")
+        if binary is None:
+            raise RuntimeError(
+                "AnthropicCLI: `claude` is not on PATH; install the Claude CLI.",
+            )
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in _NON_SUBSCRIPTION_AUTH_ENV
+        }
+        proc = subprocess.run(  # noqa: S603 -- binary resolved by shutil.which
+            [binary, "auth", "login", "--claudeai"],
+            env=env,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Claude CLI login failed with exit code {proc.returncode}.",
+            )
+        if _claude_auth_status(binary) is not True:
+            raise RuntimeError(
+                "Claude CLI login completed but no active Claude.ai "
+                "subscription login could be verified.",
+            )
 
     @override
     def model(  # ty: ignore[invalid-method-override]  -- subclasses Anthropic for the shared model catalog + auth, but the CLI transport returns a different Model and accepts provider-specific options; both still satisfy the Provider protocol's ``model(..., **provider_options)`` shape
@@ -490,9 +659,9 @@ class _AnthropicCLIModel:
                 self._spawn_spare_initialized,
                 close_partial=self._close_warming_proc,
             )
-            # Stateless mode mints a fresh tmpdir per spawn for
-            # credential isolation; the per-spawn tmpdir is local to
-            # ``_spawn_initialized``.
+            # Stateless named accounts mint an isolated HOME per spawn.
+            # The default account inherits real HOME so current macOS
+            # Claude Code can read its Keychain-backed login.
             self._persistent_tmpdir: Path | None = None
         else:
             self._hot_spare = None
@@ -1308,20 +1477,17 @@ class _AnthropicCLIModel:
             # to $HOME/.claude/.credentials.json).
             tmpdir = self._persistent_tmpdir
             spawn_owned_tmpdir = None
-        elif self._session_id is not None:
-            # Session-persistence + single account: NO HOME override.
-            # The subprocess inherits the operator's real HOME so
-            # native tools (``Bash``-from-shell, ``gh``, ``git``,
-            # ssh, ...) find ``~/.config/``, ``~/.gitconfig``, etc.,
-            # AND ``claude`` reads + writes session JSONLs at the
-            # operator's real ``~/.claude/projects/`` (which
-            # survives ``serve.py`` restarts -- a free upgrade).
+        elif self._provider.account is None:
+            # Default account, stateless or persistent: NO HOME override.
+            # On macOS the Claude CLI stores its subscription login in the
+            # Keychain rather than ``~/.claude/.credentials.json``. Inheriting
+            # HOME lets the CLI use that native login and also keeps native
+            # tools (``gh``, ``git``, ssh) on the operator's normal config.
             tmpdir = None
             spawn_owned_tmpdir = None
         else:
-            # Stateless mode: hermetic per-spawn tmpdir for
-            # credential isolation. The Subproc wrapper deletes it
-            # on close.
+            # Named-account stateless mode: hermetic per-spawn HOME holding
+            # the selected legacy file credential. Subproc deletes it on close.
             tmpdir = Path(tempfile.mkdtemp(prefix="sagent-anthropic-cli-"))
             _populate_anthropic_tmpdir(tmpdir, self._provider.account)
             spawn_owned_tmpdir = tmpdir
@@ -1646,7 +1812,7 @@ def _anthropic_subprocess_env(
     *,
     persist_session: bool = False,
 ) -> dict[str, str]:
-    """Build the env for the ``claude`` subprocess (telemetry off, hermetic HOME).
+    """Build the ``claude`` subprocess env with native or isolated auth.
 
     When ``persist_session=True`` we keep ``CLAUDE_CODE_SKIP_PROMPT_HISTORY``
     unset -- that env var (verified by bisect 2026-06-02) causes the CLI
@@ -1655,10 +1821,10 @@ def _anthropic_subprocess_env(
     no-op and the next ``--resume`` fails with "No conversation found".
 
     When ``tmpdir is None`` we don't override ``HOME`` -- the subprocess
-    inherits the operator's real HOME so claude finds its real
-    credentials + project session JSONLs AND its native tools (Bash,
-    gh, git, ...) find ``~/.config/`` and ``~/.gitconfig`` naturally.
-    Used by the session-persistent + single-account path.
+    inherits the operator's real HOME so Claude finds macOS Keychain auth,
+    project session JSONLs, and native-tool config. This is the default-account
+    path in both stateless and persistent modes. Named accounts use ``tmpdir``
+    because the CLI has no credential-file override.
 
     Auto-compact is always disabled: sagent owns history in both modes
     (stateless re-feeds it each turn; session mode rebuilds the on-disk
@@ -1667,10 +1833,15 @@ def _anthropic_subprocess_env(
     file sagent overwrites next turn, so sagent's own ``SummaryCompactor``
     is the sole compaction authority.
     """
-    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in _NON_SUBSCRIPTION_AUTH_ENV
+    }
     if tmpdir is not None:
         env["HOME"] = str(tmpdir)
         env["USERPROFILE"] = str(tmpdir)
+        env["CLAUDE_CONFIG_DIR"] = str(tmpdir / ".claude")
     env.update(
         {
             "DISABLE_TELEMETRY": "1",

--- a/sagent/providers/anthropic_cli_integration_test.py
+++ b/sagent/providers/anthropic_cli_integration_test.py
@@ -10,7 +10,8 @@ marked ``integration`` and DESELECTED by default (see ``pyproject.toml``
 
 Requirements (else the module skips):
   - ``claude`` on PATH,
-  - valid CLI credentials (``claude login`` / ``~/.claude/.credentials.json``).
+  - valid CLI credentials (``claude auth login --claudeai``; macOS may use
+    Keychain).
 
 What they cover (the production-correctness gaps the unit suite leaves):
   - a basic turn produces a non-empty ``ModelResponse``;
@@ -33,7 +34,7 @@ import uuid as _uuid
 
 import pytest
 
-from sagent.providers.anthropic_cli import AnthropicCLI
+from sagent.providers.anthropic_cli import AnthropicCLI, _claude_auth_status
 from sagent.providers.lib.oauth import credentials_path
 from sagent.providers.lib.subproc import SubprocessTransportError
 from sagent.tools import tool
@@ -56,13 +57,17 @@ pytestmark = [
 
 
 def _claude_available() -> bool:
-    if shutil.which("claude") is None:
+    binary = shutil.which("claude")
+    if binary is None:
         return False
+    status = _claude_auth_status(binary)
+    if status is not None:
+        return status
     creds = credentials_path(Path.home() / ".claude" / ".credentials.json", None)
     return creds.exists()
 
 
-_SKIP_REASON = "requires `claude` on PATH + CLI credentials"
+_SKIP_REASON = "requires `claude` on PATH + `claude auth login --claudeai`"
 _requires_claude = pytest.mark.skipif(not _claude_available(), reason=_SKIP_REASON)
 
 # The MCP bridge binds a local HTTP port; sandboxed/CI environments may

--- a/sagent/providers/anthropic_cli_test.py
+++ b/sagent/providers/anthropic_cli_test.py
@@ -25,6 +25,7 @@ from sagent.providers.anthropic_cli import (
     _AnthropicCLIModel,
     _build_anthropic_argv,
     _build_model_response,
+    _claude_auth_status,
     _dispatch_stream_event,
     _extract_retry_after_ms,
     _hash_system,
@@ -87,6 +88,21 @@ def _which_claude_stub(_name: str) -> str | None:
     return "/usr/bin/claude"
 
 
+def _auth_status_unknown(_binary: str) -> bool | None:
+    """Pretend the installed CLI predates the native status command."""
+    return None
+
+
+def _auth_status_logged_in(_binary: str) -> bool | None:
+    """Pretend the native CLI reports an active login."""
+    return True
+
+
+def _auth_status_logged_out(_binary: str) -> bool | None:
+    """Pretend the native CLI reports no active login."""
+    return False
+
+
 def test_anthropic_cli_does_not_import_subscription_provider() -> None:
     source = inspect.getsource(anthropic_cli)
     assert "providers.anthropic_sub" not in source
@@ -95,13 +111,269 @@ def test_anthropic_cli_does_not_import_subscription_provider() -> None:
 def test_from_cli_requires_credentials(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """``from_credentials`` raises ``FileNotFoundError`` if no creds file exists."""
+    """Legacy CLIs without auth status still require the credentials file."""
     monkeypatch.setattr(
         "sagent.providers.anthropic_cli._CREDS_PATH",
         tmp_path / "missing.json",
     )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.shutil.which",
+        _which_claude_stub,
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._claude_auth_status",
+        _auth_status_unknown,
+    )
     with pytest.raises(FileNotFoundError, match="no credentials"):
         AnthropicCLI.from_credentials()
+
+
+def test_from_cli_accepts_native_login_without_credentials_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The native Keychain login is authoritative without the legacy file."""
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._CREDS_PATH",
+        tmp_path / "missing.json",
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.shutil.which",
+        _which_claude_stub,
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._claude_auth_status",
+        _auth_status_logged_in,
+    )
+
+    provider = AnthropicCLI.from_credentials()
+
+    assert provider.account is None
+
+
+def test_from_cli_treats_explicit_default_account_as_native_login(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--account default`` must not bypass the macOS Keychain login."""
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._CREDS_PATH",
+        tmp_path / "missing.json",
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.shutil.which",
+        _which_claude_stub,
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._claude_auth_status",
+        _auth_status_logged_in,
+    )
+
+    provider = AnthropicCLI.from_credentials(account="default")
+
+    assert provider.account is None
+
+
+def test_from_cli_missing_named_account_does_not_suggest_native_login(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Native login cannot create Sagent's legacy named credential file."""
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._CREDS_PATH",
+        tmp_path / ".credentials.json",
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.shutil.which",
+        _which_claude_stub,
+    )
+
+    with pytest.raises(FileNotFoundError) as exc:
+        AnthropicCLI.from_credentials(account="work")
+
+    assert "named-account credentials" in str(exc.value)
+    assert "claude auth login" not in str(exc.value)
+
+
+def test_from_cli_rejects_native_logged_out_state_even_with_stale_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A stale legacy JSON file must not override an explicit logged-out state."""
+    creds = _write_creds(tmp_path)
+    monkeypatch.setattr("sagent.providers.anthropic_cli._CREDS_PATH", creds)
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.shutil.which",
+        _which_claude_stub,
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._claude_auth_status",
+        _auth_status_logged_out,
+    )
+
+    with pytest.raises(FileNotFoundError, match=r"claude auth login"):
+        AnthropicCLI.from_credentials()
+
+
+def test_claude_auth_status_scrubs_non_subscription_auth_and_reads_boolean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native status checks subscription login without leaking API-key auth."""
+    captured: dict[str, object] = {}
+
+    def fake_run(*args: object, **kwargs: object) -> object:
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return MagicMock(
+            stdout=(
+                '{"loggedIn": true, "authMethod": "claude.ai", '
+                '"apiProvider": "firstParty"}'
+            ),
+            returncode=0,
+        )
+
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://synthetic.invalid")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret-test-key")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "secret-test-token")
+    monkeypatch.setenv("ANTHROPIC_AWS_API_KEY", "secret-aws-key")
+    monkeypatch.setenv("ANTHROPIC_UNIX_SOCKET", "/synthetic/claude.sock")
+    monkeypatch.setenv("CLAUDE_CODE_API_BASE_URL", "https://synthetic.invalid")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "secret-oauth-token")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ACCESS_TOKEN", "secret-session-token")
+    monkeypatch.setenv("CLAUDE_CODE_USE_ANTHROPIC_AWS", "1")
+    monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+    monkeypatch.setenv("CLAUDE_CODE_USE_GATEWAY", "1")
+    monkeypatch.setenv("CLAUDE_CODE_USE_MANTLE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+    monkeypatch.setenv("CLAUDE_CODE_USE_FOUNDRY", "1")
+    monkeypatch.setattr("sagent.providers.anthropic_cli.subprocess.run", fake_run)
+
+    assert _claude_auth_status("/opt/homebrew/bin/claude") is True
+    assert captured["args"] == (
+        [
+            "/opt/homebrew/bin/claude",
+            "auth",
+            "status",
+            "--json",
+        ],
+    )
+    env = cast(dict[str, str], captured["env"])
+    for key in (
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_AWS_API_KEY",
+        "ANTHROPIC_UNIX_SOCKET",
+        "CLAUDE_CODE_API_BASE_URL",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CODE_SESSION_ACCESS_TOKEN",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_GATEWAY",
+        "CLAUDE_CODE_USE_MANTLE",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+    ):
+        assert key not in env
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (
+            {
+                "loggedIn": True,
+                "authMethod": "claude.ai",
+                "apiProvider": "firstParty",
+            },
+            True,
+        ),
+        ({"loggedIn": True, "authMethod": "console"}, False),
+        ({"loggedIn": True, "authMethod": "api_key"}, False),
+        ({"loggedIn": True}, None),
+        ({"loggedIn": False}, False),
+    ],
+)
+def test_claude_auth_status_requires_subscription_method(
+    monkeypatch: pytest.MonkeyPatch,
+    status: dict[str, object],
+    expected: bool | None,
+) -> None:
+    def fake_run(*_args: object, **_kwargs: object) -> object:
+        return MagicMock(
+            stdout=json.dumps(status),
+            returncode=0,
+        )
+
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.subprocess.run",
+        fake_run,
+    )
+
+    assert _claude_auth_status("/opt/homebrew/bin/claude") is expected
+
+
+def test_login_runs_native_claudeai_flow_with_scrubbed_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(*args: object, **kwargs: object) -> object:
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return MagicMock(returncode=0)
+
+    def fake_which(_name: str) -> str:
+        return "/opt/homebrew/bin/claude"
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret-test-key")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "secret-oauth-token")
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.shutil.which",
+        fake_which,
+    )
+    monkeypatch.setattr("sagent.providers.anthropic_cli.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli._claude_auth_status",
+        _auth_status_logged_in,
+    )
+
+    AnthropicCLI.login()
+
+    assert captured["args"] == (
+        [
+            "/opt/homebrew/bin/claude",
+            "auth",
+            "login",
+            "--claudeai",
+        ],
+    )
+    env = cast(dict[str, str], captured["env"])
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
+
+def test_login_rejects_named_anthropic_account() -> None:
+    with pytest.raises(ValueError, match="named accounts"):
+        AnthropicCLI.login(account="work")
+
+
+def test_login_reports_native_cli_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_which(_name: str) -> str:
+        return "/opt/homebrew/bin/claude"
+
+    def fake_run(*_args: object, **_kwargs: object) -> object:
+        return MagicMock(returncode=7)
+
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.shutil.which",
+        fake_which,
+    )
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(RuntimeError, match="exit code 7"):
+        AnthropicCLI.login()
 
 
 def test_from_cli_with_credentials(
@@ -452,14 +724,20 @@ def test_serialize_for_stdin_rejects_tool_result() -> None:
 
 
 def test_anthropic_subprocess_env_overrides_home_when_tmpdir_set(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Stateless mode (or session-persistent + per-account): tmpdir
     becomes HOME so the renamed credentials file is found.
     """
+    monkeypatch.setenv(
+        "CLAUDE_CONFIG_DIR",
+        "/operator/.claude",
+    )
     env = _anthropic_subprocess_env(tmp_path)
     assert env["HOME"] == str(tmp_path)
     assert env["USERPROFILE"] == str(tmp_path)
+    assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path / ".claude")
     # Stateless default has CLAUDE_CODE_SKIP_PROMPT_HISTORY set.
     assert env["CLAUDE_CODE_SKIP_PROMPT_HISTORY"] == "1"
 
@@ -472,6 +750,42 @@ def test_anthropic_subprocess_env_skip_history_off_when_persistent(
     """
     env = _anthropic_subprocess_env(tmp_path, persist_session=True)
     assert "CLAUDE_CODE_SKIP_PROMPT_HISTORY" not in env
+
+
+def test_anthropic_subprocess_env_strips_non_subscription_routing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    keys = (
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_AWS_API_KEY",
+        "ANTHROPIC_BEDROCK_MANTLE_API_KEY",
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+        "ANTHROPIC_IDENTITY_TOKEN",
+        "ANTHROPIC_UNIX_SOCKET",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "CLAUDE_CODE_API_BASE_URL",
+        "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
+        "CLAUDE_CODE_OAUTH_REFRESH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",
+        "CLAUDE_CODE_SESSION_ACCESS_TOKEN",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_GATEWAY",
+        "CLAUDE_CODE_USE_MANTLE",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+    )
+    for key in keys:
+        monkeypatch.setenv(key, "synthetic-test-value")
+
+    env = _anthropic_subprocess_env(None)
+
+    for key in keys:
+        assert key not in env
 
 
 def test_anthropic_subprocess_env_always_disables_autocompact(
@@ -488,6 +802,90 @@ def test_anthropic_subprocess_env_always_disables_autocompact(
 
     env_stateless = _anthropic_subprocess_env(tmp_path, persist_session=False)
     assert env_stateless.get("DISABLE_AUTO_COMPACT") == "1"
+
+
+@pytest.mark.asyncio
+async def test_stateless_default_account_inherits_native_home(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Default-account subprocesses retain macOS Keychain-backed CLI auth."""
+    operator_home = tmp_path / "operator-home"
+    monkeypatch.setenv("HOME", str(operator_home))
+    captured: dict[str, object] = {}
+
+    class _CaptureSubproc:
+        def __init__(self, argv: list[str], **kwargs: object) -> None:
+            captured["argv"] = argv
+            captured.update(kwargs)
+
+        async def start(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(anthropic_cli, "Subproc", _CaptureSubproc)
+    model = AnthropicCLI().model("claude-haiku-4-5")
+    bridge = MagicMock()
+    bridge.url = "http://127.0.0.1:1234/mcp"
+    bridge.server_name = "sagent_test"
+    bridge.has_tools = False
+    model._tools_bridge = cast(ToolsBridge, bridge)
+
+    await model._spawn_initialized()
+
+    env = cast(dict[str, str], captured["env"])
+    assert env["HOME"] == str(operator_home)
+    assert captured["tmpdir"] is None
+
+
+@pytest.mark.asyncio
+async def test_stateless_named_account_uses_isolated_file_home(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Named accounts retain the explicit file-isolation behavior."""
+    base = tmp_path / ".credentials.json"
+    named = tmp_path / ".credentials-work.json"
+    named.write_text(json.dumps(_CRED_PAYLOAD), encoding="utf-8")
+    isolated = tmp_path / "isolated-home"
+    monkeypatch.setattr("sagent.providers.anthropic_cli._CREDS_PATH", base)
+
+    def fake_mkdtemp(**_kwargs: object) -> str:
+        return str(isolated)
+
+    monkeypatch.setattr(
+        "sagent.providers.anthropic_cli.tempfile.mkdtemp",
+        fake_mkdtemp,
+    )
+    captured: dict[str, object] = {}
+
+    class _CaptureSubproc:
+        def __init__(self, argv: list[str], **kwargs: object) -> None:
+            captured["argv"] = argv
+            captured.update(kwargs)
+
+        async def start(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(anthropic_cli, "Subproc", _CaptureSubproc)
+    model = AnthropicCLI(account="work").model("claude-haiku-4-5")
+    bridge = MagicMock()
+    bridge.url = "http://127.0.0.1:1234/mcp"
+    bridge.server_name = "sagent_test"
+    bridge.has_tools = False
+    model._tools_bridge = cast(ToolsBridge, bridge)
+
+    await model._spawn_initialized()
+
+    env = cast(dict[str, str], captured["env"])
+    assert env["HOME"] == str(isolated)
+    assert captured["tmpdir"] == isolated
+    assert (isolated / ".claude" / ".credentials.json").exists()
 
 
 def test_build_model_response_normalizes_input_to_last_round() -> None:

--- a/sagent/providers/openai_sub.py
+++ b/sagent/providers/openai_sub.py
@@ -1,9 +1,9 @@
 """OpenAI subscription provider (OAuth + Codex CLI billing).
 
-Loads OAuth credentials from ``~/.codex/auth.json`` (written by
-``codex login``) and uses the OpenAI Responses API via the official
-Python SDK. Subscription billing flows through the user's ChatGPT
-plan.
+Loads OAuth credentials from ``$CODEX_HOME/auth.json`` (or
+``~/.codex/auth.json`` when unset), as written by ``codex login``, and uses
+the OpenAI Responses API via the official Python SDK. Subscription billing
+flows through the user's ChatGPT plan.
 
 Usage::
 
@@ -70,6 +70,7 @@ import dataclasses
 import inspect
 import json
 import logging
+import os
 import secrets
 import sys
 import time
@@ -183,6 +184,15 @@ _STREAM_IDLE_TIMEOUT = 600.0
 # models. A bare ``"o"`` over-matches (e.g. a future ``omni-*`` id), diverging
 # from the API-key path -- pin the exact reasoning families instead.
 _EFFORT_PREFIXES = ("o1", "o3", "o4", "gpt-5")
+
+
+def _default_credentials_path() -> Path:
+    """Return the active Codex auth file, honoring ``CODEX_HOME``."""
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "auth.json"
+    return DEFAULT_CREDENTIALS_PATH
+
 
 _FINISH_MAP: dict[str, str] = {
     "completed": "stop",
@@ -307,8 +317,8 @@ class OpenAISubscription(OpenAI):
 
         Args:
           creds: Pre-loaded credentials, or ``None`` to auto-load from disk.
-          account: Named credential slot. ``None`` uses the legacy
-            ``~/.codex/auth.json`` path.
+          account: Named credential slot. ``None`` uses the active Codex
+            ``auth.json`` under ``$CODEX_HOME`` or ``~/.codex``.
           refresh_buffer_sec: Seconds before token expiry to trigger
               proactive refresh.
 
@@ -341,8 +351,8 @@ class OpenAISubscription(OpenAI):
         Args:
           output: Stream for user-facing messages. ``None`` uses stdout.
           listener_timeout_sec: Seconds to wait for the browser callback.
-          account: Named credential slot. ``None`` writes to the legacy
-            ``~/.codex/auth.json`` path.
+          account: Named credential slot. ``None`` writes to the active Codex
+            ``auth.json`` under ``$CODEX_HOME`` or ``~/.codex``.
           manual: Print a URL and prompt for a pasted code without waiting for
             a browser callback.
 
@@ -638,7 +648,7 @@ class OpenAISubscription(OpenAI):
         """
         if not self.expired:
             return self._access_token
-        cred_path = credentials_path(DEFAULT_CREDENTIALS_PATH, self._account)
+        cred_path = credentials_path(_default_credentials_path(), self._account)
         async with self._lock, credential_file_lock(cred_path):
             if not self.expired:
                 return self._access_token
@@ -653,7 +663,7 @@ class OpenAISubscription(OpenAI):
         Holds the cross-process credential lock so a concurrent
         sibling can't refresh between our disk-check and POST.
         """
-        cred_path = credentials_path(DEFAULT_CREDENTIALS_PATH, self._account)
+        cred_path = credentials_path(_default_credentials_path(), self._account)
         async with self._lock, credential_file_lock(cred_path):
             # Adopt a sibling's fresher creds only if they are actually valid;
             # an adopted-but-expired token would 401 again on retry, so fall
@@ -716,7 +726,7 @@ class OpenAISubscription(OpenAI):
             logger.warning(
                 "OpenAI creds file at %s was unreadable; overwriting with "
                 "refreshed tokens",
-                credentials_path(DEFAULT_CREDENTIALS_PATH, self._account),
+                credentials_path(_default_credentials_path(), self._account),
             )
             creds = OpenAISubscription.Credentials(
                 access_token="",
@@ -742,8 +752,8 @@ class OpenAISubscription(OpenAI):
 
         Args:
           path: Explicit credentials file path, or ``None`` for default.
-          account: Named credential slot. ``None`` reads the legacy
-            ``~/.codex/auth.json`` path.
+          account: Named credential slot. ``None`` reads the active Codex
+            ``auth.json`` under ``$CODEX_HOME`` or ``~/.codex``.
 
         Returns:
           creds: Loaded OAuth credentials.
@@ -753,7 +763,7 @@ class OpenAISubscription(OpenAI):
           ValueError: If the file is not a complete OAuth credential record.
 
         """
-        p = path or credentials_path(DEFAULT_CREDENTIALS_PATH, account)
+        p = path or credentials_path(_default_credentials_path(), account)
         if not p.exists():
             raise FileNotFoundError(f"No credentials at {p}")
         decoded: object = json.loads(p.read_text(encoding="utf-8"))
@@ -815,11 +825,11 @@ class OpenAISubscription(OpenAI):
         Args:
           creds: OAuth credentials to persist.
           path: Explicit file path, or ``None`` for default.
-          account: Named credential slot. ``None`` writes to the legacy
-            ``~/.codex/auth.json`` path.
+          account: Named credential slot. ``None`` writes to the active Codex
+            ``auth.json`` under ``$CODEX_HOME`` or ``~/.codex``.
 
         """
-        p = path or credentials_path(DEFAULT_CREDENTIALS_PATH, account)
+        p = path or credentials_path(_default_credentials_path(), account)
         existing: MutableJSON = {}
         if p.exists():
             with contextlib.suppress(json.JSONDecodeError, OSError):

--- a/sagent/providers/openai_sub_test.py
+++ b/sagent/providers/openai_sub_test.py
@@ -611,6 +611,22 @@ def test_save_and_load_round_trip(tmp_path: Path) -> None:
     assert loaded["expires_at"] == 1700.0
 
 
+def test_default_credential_io_honors_codex_home(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Sagent follows the same relocated auth file as the Codex CLI."""
+    codex_home = tmp_path / "custom-codex-home"
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    access = _make_jwt({"exp": 1700.0})
+
+    OpenAISubscription.save(_make_creds(access, expires_at=1700.0))
+    loaded = OpenAISubscription.load()
+
+    assert (codex_home / "auth.json").exists()
+    assert loaded["access_token"] == access
+
+
 def test_save_preserves_existing_fields(tmp_path: Path) -> None:
     target = tmp_path / "auth.json"
     _write_creds_file(target, {"keep_me": True, "tokens": {"old": "x"}})

--- a/sagent/providers/providers.py
+++ b/sagent/providers/providers.py
@@ -23,17 +23,15 @@ _MODEL_PROVIDER_MAP: list[tuple[str, str]] = [
     ("minimax", "MiniMax"),
 ]
 
-# Maps API-key provider names to their account-auth (subscription /
-# credentials-file) variant. When ``infer_provider`` sees a model_id
-# whose prefix maps to an API-key provider (e.g. ``claude-...`` →
-# ``Anthropic``) AND the user's *current* provider is the account
-# variant (e.g. ``AnthropicCLI``), the inference resolves to the
-# account variant + ``credentials`` auth instead of the API-key path.
-# Without this, ``AgentSelf(model_id="claude-sonnet-4-6")`` from an
-# AnthropicCLI-backed agent would silently try to build a fresh
-# Anthropic API provider, requiring ``ANTHROPIC_API_KEY`` to be set.
+# Maps API-key provider names to their same-vendor account-auth
+# (subscription / credentials-file) variant. ``infer_provider`` keeps
+# the current account variant only when the inferred model belongs to
+# that same vendor. Cross-vendor inference retains the destination's
+# API-key default; choosing another vendor's subscription provider must
+# be explicit.
 _ACCOUNT_OVERRIDES: dict[str, str] = {
     "Anthropic": "AnthropicCLI",
+    "OpenAI": "OpenAISubscription",
 }
 _ACCOUNT_PROVIDERS: set[str] = set(_ACCOUNT_OVERRIDES.values())
 
@@ -57,12 +55,12 @@ def infer_provider(
     if _is_local_model_path(model_id):
         return ("SelfHosted", model_id)
 
-    prefer_account = current_provider in _ACCOUNT_PROVIDERS
     for prefix, base_prov in _MODEL_PROVIDER_MAP:
         if model_id.startswith(prefix):
+            account_target = _ACCOUNT_OVERRIDES.get(base_prov)
             target = (
-                _ACCOUNT_OVERRIDES.get(base_prov, base_prov)
-                if prefer_account
+                account_target
+                if account_target is not None and current_provider == account_target
                 else base_prov
             )
             if target == current_provider:

--- a/sagent/providers/providers_test.py
+++ b/sagent/providers/providers_test.py
@@ -64,25 +64,32 @@ def test_infer_provider_returns_none_when_already_matches() -> None:
 
 
 def test_infer_provider_prefers_account_variant_for_account_callers() -> None:
-    """A claude-prefixed model id resolves to the ACCOUNT provider when the
-    caller already runs on one.
+    """Same-vendor model ids preserve account auth without crossing vendors.
 
     ``AgentSelf(model_id="claude-...")`` from an AnthropicCLI-backed
     agent must not silently build a fresh API-key ``Anthropic`` provider
     (which would demand ``ANTHROPIC_API_KEY`` even though the operator
-    authenticates via the CLI subscription). Same-provider stays a
-    no-op; API-key callers are unaffected.
+    authenticates via the CLI subscription). Cross-vendor inference keeps
+    the destination's API-key default so a Claude login never implies a
+    Codex login, or vice versa.
     """
     # CLI-backed caller asking for another claude model: the override maps
     # Anthropic -> AnthropicCLI, which matches the current provider, so no
     # rebuild at all. Without the override this returned ("Anthropic",
     # "env") -- a fresh API-key provider.
     assert infer_provider("claude-haiku-4-5", current_provider="AnthropicCLI") is None
-    # Cross-vendor from a CLI caller still maps to the vendor's API path.
+    # Cross-vendor switches retain the destination provider's API-key path.
     assert infer_provider("gpt-5.5", current_provider="AnthropicCLI") == (
         "OpenAI",
         "env",
     )
+    assert (
+        infer_provider("gpt-5.6-terra", current_provider="OpenAISubscription") is None
+    )
+    assert infer_provider(
+        "claude-sonnet-4-6",
+        current_provider="OpenAISubscription",
+    ) == ("Anthropic", "env")
 
 
 def test_infer_provider_returns_none_for_unknown_prefix() -> None:

--- a/sagent/tools/agent_self_test.py
+++ b/sagent/tools/agent_self_test.py
@@ -667,7 +667,10 @@ async def test_account_default_string_is_preserved() -> None:
             result = await t.run({"model_id": "gpt-5", "account": "default"})
     assert not result.is_error
     build.assert_called_once_with(
-        "OpenAI", "env", account="default", options=ProviderOptions()
+        "OpenAISubscription",
+        "credentials",
+        account="default",
+        options=ProviderOptions(),
     )
 
 


### PR DESCRIPTION
## Why

I had trouble using my Claude Code subscription login with sagent on macOS, so I asked my coding agents to reproduce the failure, make the smallest safe fix, and verify it independently.

## Summary

Fix the existing subscription-backed providers so sagent can reliably reuse modern Claude Code and Codex logins, particularly on macOS. Both provider classes already existed; the main failure was that Claude's modern macOS login can be Keychain-backed while Sagent expected a JSON credential file.

This change:

- recognizes Claude's native `claude.ai` login through `claude auth status --json`
- lets the default Claude account inherit the real HOME for Keychain discovery while keeping named file-backed accounts isolated
- scrubs API-key, proxy, and alternate-transport environment variables from Claude subscription subprocesses
- uses the real `claude auth login --claudeai` flow, including in-session `/login`
- honors `$CODEX_HOME` for Codex credential loading, refresh, and locking
- preserves named accounts during re-login and same-vendor subscription model changes
- makes zero-flag startup try only allowed Claude/Codex subscription providers and never replace a resumed provider
- updates the macOS install command to use `pipx --backend pip`

This does not add a Homebrew formula; Sagent remains distributed through PyPI.

## Testing

- [x] `uv run pytest` — 3,920 passed, 1 skipped
- [x] focused subscription-auth suite — 115 passed
- [x] `uv run pytest -m ci_smoke -o addopts="--durations=20"`
- [x] `uv run ruff check --no-fix --no-cache .`
- [x] `uv run ruff format --check --no-cache .`
- [x] `uv run codespell .`
- [x] `uv run ty check`
- [x] `uv run basedpyright sagent`
- [x] `uv build`
- [x] `uv run python sagent/bin/check_wheel.py`
- [x] built wheel installed through pipx's pip backend and recognized existing Claude/Codex logins
- [x] two independent fresh-clone macOS/arm64 installations verified native Claude subscription discovery, Keychain-compatible HOME handling, named-account isolation, and environment scrubbing
- [x] a real `AnthropicCLI` request reached Anthropic; Sagent and native Claude returned the same account weekly-limit `429`, confirming the authentication path while successful generation remained quota-blocked
- [x] secret scan passed

## Checklist

- [x] I limited documentation changes to one changelog entry and the two affected README commands.
- [x] `docs/cli.md` and `docs/providers.md` are unchanged.
- [x] I did not include credentials, generated caches, or local environment files.
- [x] I kept lifecycle-wide provider containment in a separate follow-up.

## Codex session

This work used `gpt-5.6-sol` with `ultra` reasoning effort and parallel subagents for implementation review, packaging checks, adversarial auth testing, and independent macOS verification. 

The nine user prompts and operating instructions covered inspecting Sagent's Homebrew/pipx experience, testing Claude and Codex subscription logins, fixing the failures, separating the work into two PRs, minimizing PR 1's documentation changes, pushing it, independently testing Anthropic on macOS, and refining this description. 

At drafting time, the session recorded approximately 67.1 million processed tokens: 66,847,327 input tokens, including 65,098,240 cached tokens, and 215,472 output tokens, including 96,270 reasoning tokens. It ran against one local macOS workspace with parallel agents and no command sandbox; no credentials were printed or modified.