### PR TITLE
Document the proportional compaction buffer default

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -28,7 +28,7 @@ agent = Agent(
 max_request_tokens - max_response_tokens - buffer_tokens
 ```
 
-The default buffer is 13,000 tokens.
+The default buffer scales with the model's input window instead of being a fixed token count: `default_buffer_tokens(max_request_tokens)` returns `max_request_tokens // 15`, floored at 8,000 tokens and capped at half the window. A 200,000-token window reserves 13,333 tokens; a 400,000-token window reserves 26,666.
 
 During compaction, Sagent asks a utility model to summarize prior conversation into a continuation message. When `session_dir` exists, Sagent writes a pre-compaction transcript before replacing history.
 


### PR DESCRIPTION
The compaction guide claimed a fixed 13,000-token buffer. The default is derived from the model's input window instead (`default_buffer_tokens`: `max_request_tokens // 15`, floored at 8,000, capped at half the window), so the documented number was wrong for every window except roughly 200,000 tokens. Restates the actual rule and gives two worked values.